### PR TITLE
Add A Preview Button for only Code view on larger card

### DIFF
--- a/index.html
+++ b/index.html
@@ -116,3 +116,12 @@
   <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/highlight.min.js"></script>
 </body>
 </html>
+
+.snippets-grid pre {
+  overflow-x: auto;
+  white-space: pre;
+  max-width: 100%;
+  display: block;
+  padding: 10px;
+  box-sizing: border-box;
+}

--- a/index.html
+++ b/index.html
@@ -125,3 +125,15 @@
   padding: 10px;
   box-sizing: border-box;
 }
+
+<div class="modal-overlay" id="preview-modal-overlay" style="display:none;">
+  <div class="modal">
+    <div class="modal-header">
+      <h2>Code Preview</h2>
+      <button class="close-modal" id="close-preview-modal">&times;</button>
+    </div>
+    <div class="modal-body">
+      <pre id="preview-code" class="hljs"></pre>
+    </div>
+  </div>
+</div>

--- a/script.js
+++ b/script.js
@@ -308,3 +308,24 @@ function copyToClipboard(id) {
 window.editSnippet = editSnippet;
 window.deleteSnippet = deleteSnippet; 
 window.copyToClipboard = copyToClipboard;
+
+const previewModal = document.getElementById('preview-modal-overlay');
+const previewCode = document.getElementById('preview-code');
+const closePreviewBtn = document.getElementById('close-preview-modal');
+
+function openPreview(code) {
+  previewCode.textContent = code;
+  hljs.highlightElement(previewCode);
+  previewModal.style.display = 'flex';
+}
+
+closePreviewBtn.addEventListener('click', () => {
+  previewModal.style.display = 'none';
+});
+
+document.getElementById('snippets-grid').addEventListener('click', (e) => {
+  const snippetCard = e.target.closest('.snippet-card');
+  if (!snippetCard) return;
+  const code = snippetCard.querySelector('pre') ? snippetCard.querySelector('pre').textContent : '';
+  if(code) openPreview(code);
+});

--- a/styles.css
+++ b/styles.css
@@ -535,3 +535,29 @@ textarea {
   background-color: #28a745; /* Green color for success feedback */
   opacity: 1;
 }
+
+#preview-modal-overlay {
+  position: fixed;
+  top: 0; left: 0; right: 0; bottom: 0;
+  background: rgba(0,0,0,0.7);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+}
+
+#preview-modal-overlay .modal {
+  background: var(--background-color);
+  max-width: 90%;
+  max-height: 80%;
+  overflow: auto;
+  border-radius: 8px;
+  padding: 20px;
+  box-sizing: border-box;
+}
+
+#preview-code {
+  white-space: pre;
+  overflow-x: auto;
+  max-width: 100%;
+}


### PR DESCRIPTION
This pull request introduces a new read-only preview mode for code snippets.The new feature allows users to open a dedicated modal to comfortably inspect, read, or present code snippets without distractions from the main grid or editing controls.
changes made:
1)Added a modal overlay component that displays the selected code snippet in a highlighted, read-only format.
2)Implemented functionality to open/close the preview modal on snippet click and close button click.
3)The code inside the modal preserves formatting and supports horizontal scrolling for long lines, using syntax highlighting via Highlight.js.
The modal is responsive and styled to ensure a clear and distraction-free reading experience