### PR TITLE
Add feature Drag-and-Drop Reordering of Snippets

### DIFF
--- a/index.html
+++ b/index.html
@@ -137,3 +137,7 @@
     </div>
   </div>
 </div>
+
+<div class="snippet-card" data-id="unique-id" draggable="true">
+  <!-- snippet content -->
+</div>

--- a/index.html
+++ b/index.html
@@ -116,3 +116,12 @@
   <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/highlight.min.js"></script>
 </body>
 </html>
+
+.snippets-grid pre {
+  overflow-x: auto;
+  white-space: pre;
+  max-width: 100%;
+  display: block;
+  padding: 10px;
+  box-sizing: border-box;
+}

--- a/index.html
+++ b/index.html
@@ -125,3 +125,15 @@
   padding: 10px;
   box-sizing: border-box;
 }
+
+<div class="modal-overlay" id="preview-modal-overlay" style="display:none;">
+  <div class="modal">
+    <div class="modal-header">
+      <h2>Code Preview</h2>
+      <button class="close-modal" id="close-preview-modal">&times;</button>
+    </div>
+    <div class="modal-body">
+      <pre id="preview-code" class="hljs"></pre>
+    </div>
+  </div>
+</div>

--- a/script.js
+++ b/script.js
@@ -308,3 +308,24 @@ function copyToClipboard(id) {
 window.editSnippet = editSnippet;
 window.deleteSnippet = deleteSnippet; 
 window.copyToClipboard = copyToClipboard;
+
+const previewModal = document.getElementById('preview-modal-overlay');
+const previewCode = document.getElementById('preview-code');
+const closePreviewBtn = document.getElementById('close-preview-modal');
+
+function openPreview(code) {
+  previewCode.textContent = code;
+  hljs.highlightElement(previewCode);
+  previewModal.style.display = 'flex';
+}
+
+closePreviewBtn.addEventListener('click', () => {
+  previewModal.style.display = 'none';
+});
+
+document.getElementById('snippets-grid').addEventListener('click', (e) => {
+  const snippetCard = e.target.closest('.snippet-card');
+  if (!snippetCard) return;
+  const code = snippetCard.querySelector('pre') ? snippetCard.querySelector('pre').textContent : '';
+  if(code) openPreview(code);
+});

--- a/script.js
+++ b/script.js
@@ -329,3 +329,54 @@ document.getElementById('snippets-grid').addEventListener('click', (e) => {
   const code = snippetCard.querySelector('pre') ? snippetCard.querySelector('pre').textContent : '';
   if(code) openPreview(code);
 });
+
+
+javascript
+document.addEventListener('DOMContentLoaded', function() {
+  const snippetsGrid = document.getElementById('snippets-grid');
+  let draggedIndex = null;
+
+  snippetsGrid.addEventListener('dragstart', (e) => {
+    if (e.target.classList.contains('snippet-card')) {
+      draggedIndex = Array.from(snippetsGrid.children).indexOf(e.target);
+      e.dataTransfer.effectAllowed = 'move';
+    }
+  });
+
+  snippetsGrid.addEventListener('dragover', (e) => {
+    e.preventDefault();
+    const target = e.target.closest('.snippet-card');
+    if (!target || target === snippetsGrid.children[draggedIndex]) return;
+    const targetIndex = Array.from(snippetsGrid.children).indexOf(target);
+    if (targetIndex > draggedIndex) {
+      snippetsGrid.insertBefore(snippetsGrid.children[draggedIndex], target.nextSibling);
+    } else {
+      snippetsGrid.insertBefore(snippetsGrid.children[draggedIndex], target);
+    }
+  });
+
+  snippetsGrid.addEventListener('drop', (e) => {
+    e.preventDefault();
+    draggedIndex = null;
+    saveOrder();
+  });
+
+  function saveOrder() {
+    const order = [];
+    snippetsGrid.querySelectorAll('.snippet-card').forEach(card => {
+      order.push(card.getAttribute('data-id'));
+    });
+    localStorage.setItem('snippetsOrder', JSON.stringify(order));
+  }
+
+  function loadOrder() {
+    const order = JSON.parse(localStorage.getItem('snippetsOrder'));
+    if (!order) return;
+    order.forEach(id => {
+      const card = snippetsGrid.querySelector(`.snippet-card[data-id="${id}"]`);
+      if (card) snippetsGrid.appendChild(card);
+    });
+  }
+
+  loadOrder();
+});

--- a/styles.css
+++ b/styles.css
@@ -561,3 +561,9 @@ textarea {
   overflow-x: auto;
   max-width: 100%;
 }
+
+
+.snippet-card {
+  user-select: none;
+  cursor: move;
+}

--- a/styles.css
+++ b/styles.css
@@ -535,3 +535,29 @@ textarea {
   background-color: #28a745; /* Green color for success feedback */
   opacity: 1;
 }
+
+#preview-modal-overlay {
+  position: fixed;
+  top: 0; left: 0; right: 0; bottom: 0;
+  background: rgba(0,0,0,0.7);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+}
+
+#preview-modal-overlay .modal {
+  background: var(--background-color);
+  max-width: 90%;
+  max-height: 80%;
+  overflow: auto;
+  border-radius: 8px;
+  padding: 20px;
+  box-sizing: border-box;
+}
+
+#preview-code {
+  white-space: pre;
+  overflow-x: auto;
+  max-width: 100%;
+}


### PR DESCRIPTION
This pull request introduces manual drag-and-drop reordering for code snippets within the grid.
changes i made:
1)Enabled drag-and-drop on snippet cards with proper event handling for dragging, dragging over, and dropping.
2)Snippet cards are made draggable and the order is visually updated in real-time.
3)The new order is persisted in localStorage, so user-defined snippet layout remains consistent across sessions.
4)Added cursor styling to indicate draggable elements for better UX.